### PR TITLE
Navigation: Add Home, API & Cloud, Photos, Travel, About, Contact

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,6 +25,25 @@ params:
     highlightLanguages: ["python", "javascript", "yaml"]
 
 menu:
+  main:
+  - url: "/"
+    name: "Home"
+    weight: 1
+  - url: "/apic/"
+    name: "API & Cloud"
+    weight: 2
+  - url: "/photos/"
+    name: "Photos"
+    weight: 3
+  - url: "/travel/"
+    name: "Travel"
+    weight: 4
+  - url: "/about/"
+    name: "About"
+    weight: 5
+  - url: "mailto:ricky@rickymoorhouse.uk"
+    name: "Contact"
+    weight: 6
   icon:
   - url: "https://github.com/rickymoorhouse/"
     name: "github"
@@ -55,14 +74,29 @@ languages:
       description: "Vivo en el sur de Inglaterra con mi esposa y hijas. Yo trabajo en las ofertas de nube de IBM API Connect. Me gusta corriendo, caminando, fotografia y passando tiempo con mi familia."
     menu:
       main:
+      - url: "/"
+        name: "Inicio"
+        weight: 1
+      - url: "/apic/"
+        name: "API & Cloud"
+        weight: 2
       - url: "/photos/"
         name: "Fotos"
+        weight: 3
+      - url: "/travel/"
+        name: "Viajes"
         weight: 4
+      - url: "/about/"
+        name: "Sobre"
+        weight: 5
+      - url: "mailto:ricky@rickymoorhouse.uk"
+        name: "Contacto"
+        weight: 6
       icon:
       - url: "https://github.com/rickymoorhouse/"
         name: "github"
         weight: 2
-      - url: "https://twitter.com/rickymoorhouse/"
+      - url: "https://twitter.com/@rickymoorhouse"
         name: "twitter"
         weight: 3
       - url: "https://hachyderm.io/@ricky"


### PR DESCRIPTION
Updates the main navigation structure and adds a **Log** section for microblog posts.

## Changes

### Navigation
- **Home** (/)
- **API & Cloud** (/apic/)
- **Photos** (/photos/)
- **Travel** (/travel/)
- **About** (/about/)
- **Contact** (mailto:ricky@rickymoorhouse.uk)

### New Features
- Added **Log** section for microblog/short posts
- Updated  to include  so posts appear on homepage
- First log post: "Discovered Clawdbot"

### Spanish Navigation
- Updated equivalent menu items (Inicio, API & Cloud, Fotos, Viajes, Sobre, Contacto)

## Files Changed
-  - Navigation + mainSections
-  - First microblog post

---

To use: create posts in  and they'll appear on the homepage and at 