### PR TITLE
Only run GitHub Actions on main branch pushes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,9 @@
 ---
 name: Hugo
-on: push
+on:
+  push:
+    branches:
+      - main
 jobs:
 
   build:


### PR DESCRIPTION
Restricts the Hugo build workflow to only run when pushes are made to the main branch, preventing unnecessary builds from feature branches.